### PR TITLE
fix(Player): use this.removeBet() instead of global call

### DIFF
--- a/BlackJack/main.js
+++ b/BlackJack/main.js
@@ -71,7 +71,7 @@ class Player {
             return;
         } else if (amount < 0 && Math.abs(amount) <= this.bet) {
             // negative amount -> removing bet
-            removeBet(amount);
+            this.removeBet(amount);
             console.log("player bet: " + this.bet);
             return;
         }


### PR DESCRIPTION
## What this PR does

Fixes a bug in the `Player.placeBet()` method where negative amounts attempted to call a global `removeBet()` instead of the class method.

## Why it matters

While the current UI bypasses this logic by calling `player.removeBet()` directly, this bug could cause runtime errors if someone tries to use `placeBet()` with a negative value, such as in a future refactor or test.

## Fix Summary

- Replaces `removeBet(amount)` with `this.removeBet(amount)`
- Bug was verified via console testing and documented in Issue #34 

## Related Issue

Fixes #34 
